### PR TITLE
Add empty cart button to checkout sidebar

### DIFF
--- a/carrito.html
+++ b/carrito.html
@@ -55,6 +55,7 @@
         </div>
         <div class="bottom-carrito">
           <p>Total: $<span id="precio-total"></span></p>
+          <button id="vaciar-carrito" class="btn-button btn btn-remove-cart">Vaciar Carrito</button>
         </div>
     </aside>
     <footer>


### PR DESCRIPTION
## Summary
- add the sidebar empty-cart button to carrito.html so the script can hook into it on the checkout page

## Testing
- not run (static site changes only)

------
https://chatgpt.com/codex/tasks/task_e_68cc421ba49c83238baf9e812be970c7