### PR TITLE
Handle missing checkout total element

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -130,10 +130,12 @@ mostrarCantidadProductosCarrito()
 // PRECIO TOTAL
 
 const totalCarrito = ()=>{
-    let total = carrito.reduce((acc, producto) => acc + (producto.precio * producto.cantidad), 0) 
-    localStorage.setItem('total', total)    
+    let total = carrito.reduce((acc, producto) => acc + (producto.precio * producto.cantidad), 0)
+    localStorage.setItem('total', total)
      precioTotal.innerText = total
-     precioTotalCheckout.innerText = total
+     if (precioTotalCheckout) {
+         precioTotalCheckout.innerText = total
+     }
  }
 
 


### PR DESCRIPTION
## Summary
- guard the checkout total DOM reference before writing to it so pages without the element no longer error

## Testing
- python3 -m http.server 8000 (manual verification)
- playwright script to open index.html, toggle the cart, and ensure no console errors
- playwright script to add a product and open carrito.html to confirm the checkout total renders


------
https://chatgpt.com/codex/tasks/task_e_68cc421a14208323852a1195d1c4c648