### PR TITLE
Add guard before product grid initialization

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -50,8 +50,10 @@ const gridProductos = async() =>{
                
     })
 }
- 
-gridProductos()
+
+if (listaProductos) {
+    gridProductos()
+}
 
 // AGREGAR AL CARRITO
 


### PR DESCRIPTION
## Summary
- prevent the product grid builder from running when the product list container is missing
- keep the rest of the cart logic available so carrito.html can reuse the shared script without errors

## Testing
- python3 -m http.server 8000 (manual check via browser to ensure index.html renders products and carrito.html loads without console errors)
- curl -I http://127.0.0.1:8000/index.html
- curl -I http://127.0.0.1:8000/carrito.html

------
https://chatgpt.com/codex/tasks/task_e_68cc4212fc1483239b064ed35336f847