### PR TITLE
Ajusta vista vacía del checkout

### DIFF
--- a/js/carrito.js
+++ b/js/carrito.js
@@ -15,8 +15,9 @@ productosCarrito()
 
 const productosCarritocheckout = ()=>{
 
-    if(carrito == ""){
-        listadoProductosCheckout.innerHTML = `<h4>Carrito vacio</h4>`
+    if(!carrito.length){
+        listadoProductosCheckout.innerHTML = `<h4>Carrito vacío</h4>`
+        botonesCheckoutCarrito.style.display = 'none'
     }else{
         listadoProductosCheckout.innerHTML = ''
         carrito.forEach(producto =>{
@@ -38,7 +39,6 @@ const productosCarritocheckout = ()=>{
             div.append(btnEliminarProducto)    
             listadoProductosCheckout.append(div)
         }) 
-        
         botonesCheckoutCarrito.style.display = 'flex'
     }
 


### PR DESCRIPTION
## Summary
- replace the empty cart string comparison with a length-based check in the checkout view
- hide the checkout controls when the cart is empty and ensure they display when products are present

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc41f1a52083239781c8e4214a9d19